### PR TITLE
modules: snmp_config: multiple fixes

### DIFF
--- a/_states/sonic.py
+++ b/_states/sonic.py
@@ -12,6 +12,7 @@ There are four main parts in SONiC configuration:
 Except for BGP, a change can cause to a service unavailability (docker containers need to be
 rebooted when config is changed)
 """
+
 from salt.exceptions import CommandExecutionError
 
 __virtualname__ = "sonic"


### PR DESCRIPTION
- Avoid restarting snmp.service if the configuration hasn't changed.
- In test mode, check if a change is needed. If a change is required, set "result" to None; otherwise, set it to True.
