### PR TITLE
fix: get_route_maps not working starting 202211

### DIFF
--- a/_modules/sonic.py
+++ b/_modules/sonic.py
@@ -811,16 +811,8 @@ def get_route_maps():
             "FABRIC-IN",
         ]
     """
-    # for now we only need the name of the route-maps, ? is a small hack
-    route_map = __salt__["cmd.run"]("show route-map ?", "").split("\n")
-
-    # doing some cleaning
-    del route_map[2]
-    del route_map[1]
-    del route_map[0]
-    route_map = [r.strip() for r in route_map]
-
-    return route_map
+    cmd = "vtysh -c 'show route-map' | awk '/route-map/ {print $2}' | sort -u"
+    return __salt__["cmd.shell"](cmd).split("\n")
 
 
 def _upload_candidate_bgp_config(remote_tmpfile, content):

--- a/_states/sonic.py
+++ b/_states/sonic.py
@@ -84,7 +84,7 @@ def managed(name, templates, context=None, saltenv="base", reload_conf=False):
     return ret
 
 
-def add_user(name, password, public_keys, groups, gid=None, clear_password=True):
+def add_user(name, password, public_keys, groups, gid=None, clear_password=True):  # noqa: R0917
     """Add user.
 
     To avoid issues, users must have at least a password or a ssh key.


### PR DESCRIPTION
starting 202211, the hacky command has an issue:
```
$ show route-map ?
  <cr>  
  WORD  route-map name
     
     RM-BGP_PROV_2M203108
  json  JavaScript Object Notation
```

Let's stop doing crappy hack, and use a proper query instead :)