### PR TITLE
feat: config_db save

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.9, 3.11]
 
     steps:
     - uses: actions/checkout@v2

--- a/_modules/sonic.py
+++ b/_modules/sonic.py
@@ -531,6 +531,19 @@ def get_running_configdb():
     return data_json
 
 
+def save_running_configdb():
+    """Save running config_db configuration to startup config_db configuration.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt "sonic.tor" sonic.save_running_configdb
+    """
+    __salt__["cmd.run"]("config save")
+    return True
+
+
 def _apply_configdb_config(remote_tmpfile):
     # return nothing if done with success
     res = __salt__["cmd.run"]("sudo cp {} {}".format(remote_tmpfile, SONIC_DIR))


### PR DESCRIPTION
**Description:**

With this PR we can save the config_db the same way we can save the FRR config.

**Before the commit:**

We can't save the running config_db to the startup config_db.

**After the commit:**

We can save the running config_db to the startup config_db.
